### PR TITLE
Fix: Resolve overlapping bug in transactions table

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -136,7 +136,7 @@ const DashboardPage = () => {
               </thead>
               <tbody className="bg-white divide-[#E6E6E6]">
                 {tableData.map((row, index) => (
-                  <tr className="text-sm relative" key={index}>
+                  <tr className="text-sm" key={index}>
                     <td className="px-3 py-[10px] whitespace-nowrap text-[#146EB4] font-medium">
                       {row.orderId}
                     </td>


### PR DESCRIPTION
When scrolling up and down, the transactions body part was overlapping with the header. This issue was identified while studying week 8 Tailwind in the 100xDevs Cohort 2 by Harkirat. Initially, this issue might not be visible because there is no element below the transactions table, but it has been fixed. Hope you will accept this fix.